### PR TITLE
Update config env prefix handling

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -4,7 +4,7 @@ The `config` package provides a thread-safe configuration management system for 
 
 ## Features
 - Load configuration from YAML or JSON files.
-- Load configuration from environment variables with a prefix.
+- Load configuration from environment variables with a prefix (with or without a trailing underscore).
 - Thread-safe access to configuration values.
 - Retrieve values as strings, booleans, or string maps with defaults.
 - Define configuration fields with required and default values using struct tags.
@@ -42,12 +42,13 @@ app:
 }
 ```
 
-### Environment Variables (with prefix `CONFIG_`):
+### Environment Variables (with prefix `CONFIG`):
 ```bash
 export CONFIG_ENVIRONMENT=production
 export CONFIG_DEBUG=true
 export CONFIG_APP_NAME=my-app
 export CONFIG_APP_PORT=9090
+# The prefix can be provided to `WithEnv` with or without the trailing underscore.
 ```
 
 ### ConfigStruct
@@ -265,7 +266,7 @@ App Name: my-app
   - Options: `WithFilepath(string)`, `WithDefault(map[string]interface{})`, `WithEnv(string)`.
 - `WithFilepath(path string) Option`: Sets the configuration file path (YAML or JSON).
 - `WithDefault(defaults map[string]interface{}) Option`: Sets default configuration values, supporting nested keys (e.g., `app.name`).
-- `WithEnv(prefix string) Option`: Enables environment variable loading with the given prefix (e.g., `CONFIG`), mapping underscores to dots (e.g., `CONFIG_APP_NAME` to `app.name`).
+- `WithEnv(prefix string) Option`: Enables environment variable loading with the given prefix (e.g., `CONFIG`). The prefix may include a trailing underscore, which will be ignored. Environment variables map underscores to dots (e.g., `CONFIG_APP_NAME` to `app.name`).
 
 ### Methods
 - `Get(key string) interface{}`: Retrieves a raw configuration value.

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ func WithEnv(prefix string) Option {
 	return func(c *Config) {
 		c.mu.Lock()
 		defer c.mu.Unlock()
+		prefix = strings.TrimSuffix(prefix, "_")
 		c.v.SetEnvPrefix(strings.ToUpper(prefix))
 		c.v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 		c.v.AutomaticEnv()

--- a/config/examples/simple_env/main.go
+++ b/config/examples/simple_env/main.go
@@ -14,7 +14,8 @@ import (
 
 func main() {
 	// Initialize config with environment variables
-	cfg, err := config.New(config.WithEnv("CONFIG_"))
+	// The prefix can include a trailing underscore, which is ignored.
+	cfg, err := config.New(config.WithEnv("CONFIG"))
 	if err != nil {
 		fmt.Printf("Failed to initialize config: %v\n", err)
 		return


### PR DESCRIPTION
## Summary
- allow trailing underscore in `WithEnv`
- document new behavior
- fix simple_env example

## Testing
- `go test ./config -v`
- `go test ./...`
