### PR TITLE
Add StartSpan helper for otel spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,9 @@ Helpers for integrating OpenTelemetry into your application with support for tra
 ```go
 import "github.com/T-Prohmpossadhorn/go-core/otel"
 
-otelTracer := otel.NewTracer("my-service")
-ctx, span := otelTracer.Start(context.Background(), "my-operation")
+ctx, span := otel.StartSpan(context.Background(), "my-service", "my-operation")
+defer span.End()
 // ... perform work ...
-span.End()
 ```
 
 ---

--- a/otel/README.md
+++ b/otel/README.md
@@ -17,7 +17,7 @@ The `otel` package is a lightweight, thread-safe OpenTelemetry setup for distrib
 
 ## Features
 - **OpenTelemetry Tracing**: Initializes a `TracerProvider` with an OTLP gRPC exporter for production or a mock exporter for testing.
-- **Span Management**: Provides `GetTracer` for creating named tracers and spans.
+- **Span Management**: Provides `GetTracer` and `StartSpan` for creating named tracers and spans without extra boilerplate.
 - **Thread-Safety**: Uses `sync.RWMutex` for safe concurrent access to the `TracerProvider`.
 - **Integration**: Leverages `config` for settings and `logger` for trace-aware logging (`trace_id`, `span_id`).
 - **Dynamic Log Level**: Automatically sets the log level to `debug` when the
@@ -90,9 +90,8 @@ func main() {
     }
     defer otel.Shutdown(context.Background())
 
-    // Create a tracer and start a span
-    tracer := otel.GetTracer("example-service")
-    ctx, span := tracer.Start(context.Background(), "process-request")
+    // Start a span directly without retrieving a tracer first
+    ctx, span := otel.StartSpan(context.Background(), "example-service", "process-request")
     defer span.End()
 
     // Simulate work
@@ -138,9 +137,8 @@ func main() {
     }
     defer otel.Shutdown(context.Background())
 
-    // Create a tracer and start a span
-    tracer := otel.GetTracer("user-service")
-    ctx, span := tracer.Start(context.Background(), "handle-user-request")
+    // Start a span directly without retrieving a tracer first
+    ctx, span := otel.StartSpan(context.Background(), "user-service", "handle-user-request")
     defer span.End()
 
     // Log with trace context
@@ -200,9 +198,8 @@ func main() {
     }
     defer otel.Shutdown(context.Background())
 
-    // Create a tracer and start a span
-    tracer := otel.GetTracer("order-service")
-    ctx, span := tracer.Start(context.Background(), "process-order")
+    // Start a span directly without retrieving a tracer first
+    ctx, span := otel.StartSpan(context.Background(), "order-service", "process-order")
     defer span.End()
 
     // Add baggage
@@ -221,8 +218,7 @@ func main() {
 
     // Simulate downstream service call with extracted context
     downstreamCtx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.MapCarrier(carrier))
-    downstreamTracer := otel.GetTracer("payment-service")
-    downstreamCtx, downstreamSpan := downstreamTracer.Start(downstreamCtx, "process-payment")
+    downstreamCtx, downstreamSpan := otel.StartSpan(downstreamCtx, "payment-service", "process-payment")
     defer downstreamSpan.End()
 
     logger.InfoContext(downstreamCtx, "Processing payment",

--- a/otel/examples/main.go
+++ b/otel/examples/main.go
@@ -27,9 +27,8 @@ func main() {
 	}
 	defer otel.Shutdown(context.Background())
 
-	// Create tracer and span
-	tracer := otel.GetTracer("example")
-	ctx, span := tracer.Start(context.Background(), "example-span")
+	// Create a span without retrieving the tracer first
+	ctx, span := otel.StartSpan(context.Background(), "example", "example-span")
 	defer span.End()
 
 	// Log with span context

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -186,3 +186,11 @@ func GetTracer(name string) oteltrace.Tracer {
 	logger.Debug("Returning tracer", logger.String("name", name), logger.Any("tracerProvider", tracerProvider))
 	return tracerProvider.Tracer(name)
 }
+
+// StartSpan is a convenience function that retrieves a tracer by name and
+// starts a span in a single call. It falls back to a noop tracer when the
+// tracer provider has not been initialized.
+func StartSpan(ctx context.Context, tracerName, spanName string) (context.Context, oteltrace.Span) {
+	tracer := GetTracer(tracerName)
+	return tracer.Start(ctx, spanName)
+}


### PR DESCRIPTION
## Summary
- add `StartSpan` function for starting spans without fetching the tracer
- update docs and example usage
- test the helper for initialized and uninitialized states

## Testing
- `go test ./...`