### PR TITLE
Add Swagger UI endpoint and full HTTP method support

### DIFF
--- a/httpc/types.go
+++ b/httpc/types.go
@@ -1,6 +1,7 @@
 package httpc
 
 import (
+	"net/http"
 	"reflect"
 	"strings"
 )
@@ -30,7 +31,17 @@ func WithPathPrefix(prefix string) ServiceOption {
 
 // isValidHTTPMethod checks if the given method is a valid HTTP method
 func isValidHTTPMethod(method string) bool {
-	validMethods := []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"}
+	validMethods := []string{
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodPatch,
+		http.MethodOptions,
+		http.MethodHead,
+		http.MethodConnect,
+		http.MethodTrace,
+	}
 	for _, valid := range validMethods {
 		if strings.ToUpper(method) == valid {
 			return true


### PR DESCRIPTION
## Summary
- expose Swagger UI at `/api/docs/index.html`
- register HTTP handlers using `engine.Handle` to support all standard methods
- add HEAD response handling
- recognize CONNECT and TRACE in `isValidHTTPMethod`
- test Swagger UI endpoint

## Testing
- `go test ./...`
