### PR TITLE
Add Kafka module

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ defer rmq.Close()
 rmq.Publish(context.Background(), "q", []byte("hello"))
 ```
 
+### kafka
+
+An in-memory queue with a Kafka-style API.
+
+**Example:**
+
+```go
+import (
+    "context"
+    "github.com/T-Prohmpossadhorn/go-core/config"
+    "github.com/T-Prohmpossadhorn/go-core/kafka"
+)
+
+cfg, _ := config.New()
+k, _ := kafka.New(cfg)
+defer k.Close()
+k.Publish(context.Background(), "q", []byte("hello"))
+```
+
 ---
 
 ## Testing
@@ -104,6 +123,7 @@ go-core/
 ├── otel/           # OpenTelemetry support
 ├── httpc/          # HTTP server and client
 ├── rabbitmq/       # In-memory message queue
+├── kafka/          # In-memory message queue
 ├── go.mod
 ├── go.sum
 └── README.md
@@ -135,3 +155,4 @@ T-Prohmpossadhorn
 - [otel/README.md](https://github.com/T-Prohmpossadhorn/go-core/blob/main/otel/README.md)
 - [httpc/README.md](https://github.com/T-Prohmpossadhorn/go-core/blob/main/httpc/README.md)
 - [rabbitmq/README.md](https://github.com/T-Prohmpossadhorn/go-core/blob/main/rabbitmq/README.md)
+- [kafka/README.md](https://github.com/T-Prohmpossadhorn/go-core/blob/main/kafka/README.md)

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,0 +1,64 @@
+# kafka Package
+
+The `kafka` package provides a lightweight, in-memory message queue with an API inspired by Kafka. It mirrors the style of the `rabbitmq` package, integrating with `config` and `logger` for easy configuration and structured logging. This implementation does **not** connect to an actual Kafka broker; it is a simple, thread-safe queue useful for local testing or demonstration purposes.
+
+## Table of Contents
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Publishing Messages](#publishing-messages)
+  - [Consuming Messages](#consuming-messages)
+- [Configuration](#configuration)
+- [Examples](#examples)
+- [License](#license)
+
+## Features
+- **In-Memory Topics**: Send and receive messages without an external broker.
+- **Config Integration**: Uses the `config` package to load settings such as `kafka_brokers`, `kafka_topic`, and `otel_enabled`.
+- **Structured Logging**: Leverages the `logger` package for contextual logs.
+- **Optional Tracing**: Placeholder field for OpenTelemetry support.
+- **Graceful Shutdown**: Close all topics with `Close()`.
+
+## Installation
+```bash
+go get github.com/T-Prohmpossadhorn/go-core/kafka
+```
+
+## Usage
+### Publishing Messages
+```go
+cfg, _ := config.New(config.WithDefault(map[string]interface{}{
+    "kafka_brokers": "localhost:9092",
+}))
+k, _ := kafka.New(cfg)
+ctx := context.Background()
+if err := k.Publish(ctx, "tasks", []byte("hello")); err != nil {
+    panic(err)
+}
+```
+
+### Consuming Messages
+```go
+ctx := context.Background()
+msgs, _ := k.Consume(ctx, "tasks")
+for msg := range msgs {
+    fmt.Println(string(msg))
+}
+```
+
+## Configuration
+| Key            | Type   | Default          |
+|----------------|-------|------------------|
+| `kafka_brokers`| string | `localhost:9092` |
+| `kafka_topic`  | string | `default`        |
+| `otel_enabled` | bool   | `false`          |
+
+## Examples
+Run the producer and consumer examples:
+```bash
+go run ./kafka/examples/producer
+go run ./kafka/examples/consumer
+```
+
+## License
+MIT License. See `LICENSE` file.

--- a/kafka/examples/consumer/main.go
+++ b/kafka/examples/consumer/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/T-Prohmpossadhorn/go-core/kafka"
+	"github.com/T-Prohmpossadhorn/go-core/logger"
+)
+
+func main() {
+	logger.Init()
+	defer logger.Sync()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	k, _ := kafka.New(cfg)
+	defer k.Close()
+
+	msgs, _ := k.Consume(context.Background(), "tasks")
+	for msg := range msgs {
+		fmt.Println(string(msg))
+	}
+}

--- a/kafka/examples/producer/main.go
+++ b/kafka/examples/producer/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/T-Prohmpossadhorn/go-core/kafka"
+	"github.com/T-Prohmpossadhorn/go-core/logger"
+)
+
+func main() {
+	logger.Init()
+	defer logger.Sync()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{
+		"kafka_brokers": "localhost:9092",
+	}))
+	k, _ := kafka.New(cfg)
+	defer k.Close()
+
+	k.Publish(context.Background(), "tasks", []byte("hello"))
+}

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -1,0 +1,101 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/T-Prohmpossadhorn/go-core/logger"
+)
+
+// Config defines Kafka settings.
+type Config struct {
+	OtelEnabled bool   `mapstructure:"otel_enabled" default:"false"`
+	Brokers     string `mapstructure:"kafka_brokers" default:"localhost:9092"`
+	Topic       string `mapstructure:"kafka_topic" default:"default"`
+}
+
+// Kafka is an in-memory message queue used for demonstration.
+type Kafka struct {
+	mu     sync.RWMutex
+	topics map[string]chan []byte
+	cfg    Config
+}
+
+// New creates a new Kafka instance with the provided config.
+func New(c *config.Config) (*Kafka, error) {
+	cfg := Config{
+		OtelEnabled: c.GetBool("otel_enabled"),
+		Brokers:     c.GetStringWithDefault("kafka_brokers", "localhost:9092"),
+		Topic:       c.GetStringWithDefault("kafka_topic", "default"),
+	}
+
+	k := &Kafka{
+		topics: make(map[string]chan []byte),
+		cfg:    cfg,
+	}
+	logger.Info("Kafka initialized", logger.String("brokers", cfg.Brokers), logger.String("topic", cfg.Topic))
+	return k, nil
+}
+
+// Publish sends a message to the specified topic.
+func (k *Kafka) Publish(ctx context.Context, topic string, body []byte) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("publish canceled: %w", ctx.Err())
+	}
+
+	k.mu.Lock()
+	q, ok := k.topics[topic]
+	if !ok {
+		q = make(chan []byte, 100)
+		k.topics[topic] = q
+	}
+	k.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("publish canceled: %w", ctx.Err())
+	case q <- body:
+		logger.InfoContext(ctx, "Message published", logger.String("topic", topic))
+		return nil
+	}
+}
+
+// Consume returns a channel to receive messages from the specified topic.
+func (k *Kafka) Consume(ctx context.Context, topic string) (<-chan []byte, error) {
+	k.mu.Lock()
+	q, ok := k.topics[topic]
+	if !ok {
+		q = make(chan []byte, 100)
+		k.topics[topic] = q
+	}
+	k.mu.Unlock()
+
+	out := make(chan []byte)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case msg := <-q:
+				out <- msg
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	logger.InfoContext(ctx, "Consumer registered", logger.String("topic", topic))
+	return out, nil
+}
+
+// Close closes all topics.
+func (k *Kafka) Close() error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	for name, ch := range k.topics {
+		close(ch)
+		delete(k.topics, name)
+	}
+	logger.Info("Kafka closed")
+	return nil
+}

--- a/kafka/kafka_test.go
+++ b/kafka/kafka_test.go
@@ -1,0 +1,35 @@
+package kafka
+
+import (
+	"context"
+	"testing"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishConsume(t *testing.T) {
+	cfg, err := config.New(config.WithDefault(map[string]interface{}{}))
+	require.NoError(t, err)
+	k, err := New(cfg)
+	require.NoError(t, err)
+	defer k.Close()
+
+	ctx := context.Background()
+	require.NoError(t, k.Publish(ctx, "q", []byte("hi")))
+	msgs, err := k.Consume(ctx, "q")
+	require.NoError(t, err)
+	msg := <-msgs
+	require.Equal(t, []byte("hi"), msg)
+}
+
+func TestPublishCanceled(t *testing.T) {
+	cfg, _ := config.New()
+	k, _ := New(cfg)
+	defer k.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := k.Publish(ctx, "q", []byte("hi"))
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- add a new `kafka` package that mimics RabbitMQ but uses topics
- include examples and tests for the Kafka package
- document Kafka usage in the project README

## Testing
- `go test ./...`
