### PR TITLE
Add OpenTelemetry support for message queues

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,64 +1,167 @@
 # kafka Package
 
-The `kafka` package provides a lightweight, in-memory message queue with an API inspired by Kafka. It mirrors the style of the `rabbitmq` package, integrating with `config` and `logger` for easy configuration and structured logging. This implementation does **not** connect to an actual Kafka broker; it is a simple, thread-safe queue useful for local testing or demonstration purposes.
+The `kafka` package implements an in-memory message queue with an API reminiscent of Apache Kafka. It integrates with the `config`, `logger`, and `otel` packages in this monorepo and is intended for development or testing scenarios where a real Kafka broker would be overkill.
 
 ## Table of Contents
 - [Features](#features)
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Publishing Messages](#publishing-messages)
+  - [Producing Messages](#producing-messages)
   - [Consuming Messages](#consuming-messages)
+  - [Tracing with OpenTelemetry](#tracing-with-opentelemetry)
 - [Configuration](#configuration)
 - [Examples](#examples)
+- [Testing](#testing)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
 - [License](#license)
 
 ## Features
-- **In-Memory Topics**: Send and receive messages without an external broker.
-- **Config Integration**: Uses the `config` package to load settings such as `kafka_brokers`, `kafka_topic`, and `otel_enabled`.
-- **Structured Logging**: Leverages the `logger` package for contextual logs.
-- **Optional Tracing**: Placeholder field for OpenTelemetry support.
-- **Graceful Shutdown**: Close all topics with `Close()`.
+- **In-Memory Topics**: No external Kafka broker required.
+- **Config Integration**: Load `kafka_brokers`, `kafka_topic`, and `otel_enabled` using the `config` package.
+- **Structured Logging**: `logger` provides context-aware logs.
+- **OpenTelemetry Support**: When enabled, operations create spans with the `otel` package.
+- **Thread-Safe**: Uses `sync.RWMutex` for safe concurrent access to topics.
+- **Graceful Shutdown**: Close all topics and release resources with `Close()`.
 
 ## Installation
+Install the package:
+
 ```bash
 go get github.com/T-Prohmpossadhorn/go-core/kafka
 ```
 
+### Dependencies
+- `github.com/T-Prohmpossadhorn/go-core/config`
+- `github.com/T-Prohmpossadhorn/go-core/logger`
+- `github.com/T-Prohmpossadhorn/go-core/otel`
+
+Add them to your project as needed:
+
+```bash
+go get github.com/T-Prohmpossadhorn/go-core/config
+go get github.com/T-Prohmpossadhorn/go-core/logger
+go get github.com/T-Prohmpossadhorn/go-core/otel
+```
+
 ## Usage
-### Publishing Messages
+Create a new instance with `New`, publish messages with `Publish`, and consume them with `Consume`.
+
+### Producing Messages
+
 ```go
-cfg, _ := config.New(config.WithDefault(map[string]interface{}{
-    "kafka_brokers": "localhost:9092",
-}))
-k, _ := kafka.New(cfg)
-ctx := context.Background()
-if err := k.Publish(ctx, "tasks", []byte("hello")); err != nil {
-    panic(err)
+package main
+
+import (
+    "context"
+
+    "github.com/T-Prohmpossadhorn/go-core/config"
+    "github.com/T-Prohmpossadhorn/go-core/logger"
+    "github.com/T-Prohmpossadhorn/go-core/kafka"
+)
+
+func main() {
+    logger.Init()
+    defer logger.Sync()
+
+    cfg, _ := config.New(config.WithDefault(map[string]interface{}{
+        "kafka_brokers": "localhost:9092",
+    }))
+    k, _ := kafka.New(cfg)
+    defer k.Close()
+
+    _ = k.Publish(context.Background(), "tasks", []byte("hello"))
 }
 ```
 
 ### Consuming Messages
+
 ```go
-ctx := context.Background()
-msgs, _ := k.Consume(ctx, "tasks")
-for msg := range msgs {
-    fmt.Println(string(msg))
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/T-Prohmpossadhorn/go-core/config"
+    "github.com/T-Prohmpossadhorn/go-core/logger"
+    "github.com/T-Prohmpossadhorn/go-core/kafka"
+)
+
+func main() {
+    logger.Init()
+    defer logger.Sync()
+
+    cfg, _ := config.New()
+    k, _ := kafka.New(cfg)
+    defer k.Close()
+
+    msgs, _ := k.Consume(context.Background(), "tasks")
+    for msg := range msgs {
+        fmt.Println(string(msg))
+    }
 }
 ```
 
+### Tracing with OpenTelemetry
+Enable tracing by setting `otel_enabled` to `true` and initializing the `otel` package:
+
+```go
+cfg, _ := config.New(config.WithDefault(map[string]interface{}{
+    "otel_enabled": true,
+}))
+
+os.Setenv("OTEL_TEST_MOCK_EXPORTER", "true")
+defer os.Unsetenv("OTEL_TEST_MOCK_EXPORTER")
+_ = otel.Init(cfg)
+defer otel.Shutdown(context.Background())
+
+k, _ := kafka.New(cfg)
+ctx := context.Background()
+_ = k.Publish(ctx, "tasks", []byte("traced"))
+```
+
+With tracing enabled, log entries include `trace_id` and `span_id` so you can correlate events across services.
+
 ## Configuration
-| Key            | Type   | Default          |
-|----------------|-------|------------------|
-| `kafka_brokers`| string | `localhost:9092` |
-| `kafka_topic`  | string | `default`        |
-| `otel_enabled` | bool   | `false`          |
+| Key             | Type   | Default          |
+| --------------- | ------ | ---------------- |
+| `kafka_brokers` | string | `localhost:9092` |
+| `kafka_topic`   | string | `default`        |
+| `otel_enabled`  | bool   | `false`          |
+
+Configuration can be loaded from files or environment variables. Example environment usage:
+
+```bash
+export CONFIG_KAFKA_BROKERS=localhost:9092
+export CONFIG_OTEL_ENABLED=true
+```
 
 ## Examples
-Run the producer and consumer examples:
+Run the producer and consumer examples found in `kafka/examples`:
+
 ```bash
 go run ./kafka/examples/producer
 go run ./kafka/examples/consumer
 ```
 
+## Testing
+Run the unit tests:
+
+```bash
+cd kafka
+go test -v -cover
+```
+
+Tests cover publishing, consuming, and tracing using the mock exporter to avoid external dependencies.
+
+## Troubleshooting
+- **Tracing Disabled**: Confirm `otel_enabled` is true and `otel.Init` completed successfully.
+- **Context Errors**: Operations fail when the provided context is canceled.
+- **Topic Not Found**: Topics are created on demand when publishing or consuming.
+
+## Contributing
+Feedback and contributions are encouraged! Open an issue or pull request on GitHub and ensure `go test ./...` passes before submission.
+
 ## License
-MIT License. See `LICENSE` file.
+MIT License. See the `LICENSE` file for full details.

--- a/kafka/kafka_test.go
+++ b/kafka/kafka_test.go
@@ -1,12 +1,76 @@
 package kafka
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/T-Prohmpossadhorn/go-core/logger"
+	"github.com/T-Prohmpossadhorn/go-core/otel"
 	"github.com/stretchr/testify/require"
 )
+
+// syncWriter is a thread-safe writer for capturing logs
+type syncWriter struct {
+	buf *bytes.Buffer
+	mu  sync.Mutex
+}
+
+func (sw *syncWriter) Write(p []byte) (n int, err error) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.buf.Write(p)
+}
+
+func setupLogger(t *testing.T) (*syncWriter, *os.File, func()) {
+	var logBuf bytes.Buffer
+	logWriter := &syncWriter{buf: &logBuf}
+	originalStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+	go func() {
+		_, _ = logBuf.ReadFrom(r)
+		time.Sleep(200 * time.Millisecond)
+		r.Close()
+	}()
+	err = logger.InitWithConfig(logger.LoggerConfig{
+		Level:      "info",
+		Output:     "console",
+		JSONFormat: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to initialize logger: %v", err)
+	}
+	return logWriter, w, func() {
+		logger.Sync()
+		time.Sleep(200 * time.Millisecond)
+		w.Close()
+		os.Stdout = originalStdout
+	}
+}
+
+func getLogs(writer *syncWriter) string {
+	logger.Sync()
+	time.Sleep(200 * time.Millisecond)
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.buf.String()
+}
+
+func resetLogs(writer *syncWriter) {
+	logger.Sync()
+	time.Sleep(200 * time.Millisecond)
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	writer.buf.Reset()
+}
 
 func TestPublishConsume(t *testing.T) {
 	cfg, err := config.New(config.WithDefault(map[string]interface{}{}))
@@ -32,4 +96,31 @@ func TestPublishCanceled(t *testing.T) {
 	cancel()
 	err := k.Publish(ctx, "q", []byte("hi"))
 	require.Error(t, err)
+}
+
+func TestPublishTracing(t *testing.T) {
+	logWriter, _, cleanup := setupLogger(t)
+	defer cleanup()
+	resetLogs(logWriter)
+
+	cfg, err := config.New(config.WithDefault(map[string]interface{}{
+		"otel_enabled": true,
+	}))
+	require.NoError(t, err)
+
+	os.Setenv("OTEL_TEST_MOCK_EXPORTER", "true")
+	defer os.Unsetenv("OTEL_TEST_MOCK_EXPORTER")
+	require.NoError(t, otel.Init(cfg))
+	defer otel.Shutdown(context.Background())
+
+	k, err := New(cfg)
+	require.NoError(t, err)
+	defer k.Close()
+
+	ctx := context.Background()
+	require.NoError(t, k.Publish(ctx, "q", []byte("hi")))
+
+	logs := getLogs(logWriter)
+	require.Contains(t, logs, "\"trace_id\"")
+	require.Contains(t, logs, "\"span_id\"")
 }

--- a/rabbitmq/rabbitmq_test.go
+++ b/rabbitmq/rabbitmq_test.go
@@ -1,12 +1,76 @@
 package rabbitmq
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/T-Prohmpossadhorn/go-core/logger"
+	"github.com/T-Prohmpossadhorn/go-core/otel"
 	"github.com/stretchr/testify/require"
 )
+
+// syncWriter is a thread-safe writer for capturing logs
+type syncWriter struct {
+	buf *bytes.Buffer
+	mu  sync.Mutex
+}
+
+func (sw *syncWriter) Write(p []byte) (n int, err error) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.buf.Write(p)
+}
+
+func setupLogger(t *testing.T) (*syncWriter, *os.File, func()) {
+	var logBuf bytes.Buffer
+	logWriter := &syncWriter{buf: &logBuf}
+	originalStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+	go func() {
+		_, _ = logBuf.ReadFrom(r)
+		time.Sleep(200 * time.Millisecond)
+		r.Close()
+	}()
+	err = logger.InitWithConfig(logger.LoggerConfig{
+		Level:      "info",
+		Output:     "console",
+		JSONFormat: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to initialize logger: %v", err)
+	}
+	return logWriter, w, func() {
+		logger.Sync()
+		time.Sleep(200 * time.Millisecond)
+		w.Close()
+		os.Stdout = originalStdout
+	}
+}
+
+func getLogs(writer *syncWriter) string {
+	logger.Sync()
+	time.Sleep(200 * time.Millisecond)
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	return writer.buf.String()
+}
+
+func resetLogs(writer *syncWriter) {
+	logger.Sync()
+	time.Sleep(200 * time.Millisecond)
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	writer.buf.Reset()
+}
 
 func TestPublishConsume(t *testing.T) {
 	cfg, err := config.New(config.WithDefault(map[string]interface{}{}))
@@ -32,4 +96,31 @@ func TestPublishCanceled(t *testing.T) {
 	cancel()
 	err := rmq.Publish(ctx, "q", []byte("hi"))
 	require.Error(t, err)
+}
+
+func TestPublishTracing(t *testing.T) {
+	logWriter, _, cleanup := setupLogger(t)
+	defer cleanup()
+	resetLogs(logWriter)
+
+	cfg, err := config.New(config.WithDefault(map[string]interface{}{
+		"otel_enabled": true,
+	}))
+	require.NoError(t, err)
+
+	os.Setenv("OTEL_TEST_MOCK_EXPORTER", "true")
+	defer os.Unsetenv("OTEL_TEST_MOCK_EXPORTER")
+	require.NoError(t, otel.Init(cfg))
+	defer otel.Shutdown(context.Background())
+
+	rmq, err := New(cfg)
+	require.NoError(t, err)
+	defer rmq.Close()
+
+	ctx := context.Background()
+	require.NoError(t, rmq.Publish(ctx, "q", []byte("hi")))
+
+	logs := getLogs(logWriter)
+	require.Contains(t, logs, "\"trace_id\"")
+	require.Contains(t, logs, "\"span_id\"")
 }


### PR DESCRIPTION
## Summary
- add OTEL spans in `rabbitmq` and `kafka`
- expand `rabbitmq` and `kafka` README docs with tracing usage
- test tracing logs in message queue packages

## Testing
- `go test ./...`