### PR TITLE
Improve queue test coverage and add otel examples

### DIFF
--- a/kafka/examples/otel/main.go
+++ b/kafka/examples/otel/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/T-Prohmpossadhorn/go-core/kafka"
+	"github.com/T-Prohmpossadhorn/go-core/logger"
+	"github.com/T-Prohmpossadhorn/go-core/otel"
+)
+
+func main() {
+	logger.Init()
+	defer logger.Sync()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{
+		"otel_enabled": true,
+	}))
+
+	// Use mock exporter for demonstration
+	os.Setenv("OTEL_TEST_MOCK_EXPORTER", "true")
+	defer os.Unsetenv("OTEL_TEST_MOCK_EXPORTER")
+	otel.Init(cfg)
+	defer otel.Shutdown(context.Background())
+
+	k, _ := kafka.New(cfg)
+	defer k.Close()
+
+	ctx, span := otel.StartSpan(context.Background(), "kafka-example", "publish")
+	defer span.End()
+
+	_ = k.Publish(ctx, "tasks", []byte("hello"))
+}

--- a/kafka/mock_test.go
+++ b/kafka/mock_test.go
@@ -1,0 +1,96 @@
+package kafka
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	kafka_go "github.com/segmentio/kafka-go"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/stretchr/testify/require"
+)
+
+type mockWriter struct{ msgs []kafka_go.Message }
+
+func (m *mockWriter) WriteMessages(ctx context.Context, msgs ...kafka_go.Message) error {
+	m.msgs = append(m.msgs, msgs...)
+	return nil
+}
+
+func (m *mockWriter) Close() error { return nil }
+
+type mockReader struct{ ch chan kafka_go.Message }
+
+func (m *mockReader) ReadMessage(ctx context.Context) (kafka_go.Message, error) {
+	msg, ok := <-m.ch
+	if !ok {
+		return kafka_go.Message{}, io.EOF
+	}
+	return msg, nil
+}
+
+func (m *mockReader) Close() error { return nil }
+
+func TestKafkaPublishConsumeMock(t *testing.T) {
+	mw := &mockWriter{}
+	mr := &mockReader{ch: make(chan kafka_go.Message, 1)}
+	mr.ch <- kafka_go.Message{Value: []byte("consumed")}
+	close(mr.ch)
+
+	origW, origR := writerFactoryFunc, readerFactoryFunc
+	writerFactoryFunc = func([]string, string) writer { return mw }
+	readerFactoryFunc = func([]string, string) reader { return mr }
+	defer func() { writerFactoryFunc, readerFactoryFunc = origW, origR }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	k, err := New(cfg)
+	require.NoError(t, err)
+
+	out, err := k.Consume(context.Background(), "t1")
+	require.NoError(t, err)
+
+	require.NoError(t, k.Publish(context.Background(), "t1", []byte("hello")))
+	require.Len(t, mw.msgs, 1)
+	require.Equal(t, []byte("hello"), mw.msgs[0].Value)
+
+	msg := <-out
+	require.Equal(t, []byte("consumed"), msg)
+}
+
+func TestKafkaCloseMock(t *testing.T) {
+	mw := &mockWriter{}
+	mr := &mockReader{ch: make(chan kafka_go.Message)}
+
+	origW, origR := writerFactoryFunc, readerFactoryFunc
+	writerFactoryFunc = func([]string, string) writer { return mw }
+	readerFactoryFunc = func([]string, string) reader { return mr }
+	defer func() { writerFactoryFunc, readerFactoryFunc = origW, origR }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	k, err := New(cfg)
+	require.NoError(t, err)
+
+	_, err = k.Consume(context.Background(), "t1")
+	require.NoError(t, err)
+	require.NoError(t, k.Publish(context.Background(), "t1", []byte("x")))
+
+	require.NoError(t, k.Close())
+}
+
+func TestKafkaPublishCanceledMock(t *testing.T) {
+	mw := &mockWriter{}
+
+	origW := writerFactoryFunc
+	writerFactoryFunc = func([]string, string) writer { return mw }
+	defer func() { writerFactoryFunc = origW }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	k, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = k.Publish(ctx, "t1", []byte("x"))
+	require.Error(t, err)
+}

--- a/rabbitmq/examples/otel/main.go
+++ b/rabbitmq/examples/otel/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/T-Prohmpossadhorn/go-core/logger"
+	"github.com/T-Prohmpossadhorn/go-core/otel"
+	"github.com/T-Prohmpossadhorn/go-core/rabbitmq"
+)
+
+func main() {
+	logger.Init()
+	defer logger.Sync()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{
+		"otel_enabled": true,
+	}))
+
+	// Use mock exporter for demonstration
+	os.Setenv("OTEL_TEST_MOCK_EXPORTER", "true")
+	defer os.Unsetenv("OTEL_TEST_MOCK_EXPORTER")
+	otel.Init(cfg)
+	defer otel.Shutdown(context.Background())
+
+	rmq, _ := rabbitmq.New(cfg)
+	defer rmq.Close()
+
+	ctx, span := otel.StartSpan(context.Background(), "rabbitmq-example", "publish")
+	defer span.End()
+
+	_ = rmq.Publish(ctx, "tasks", []byte("hello"))
+}

--- a/rabbitmq/mock_test.go
+++ b/rabbitmq/mock_test.go
@@ -1,0 +1,208 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	"github.com/T-Prohmpossadhorn/go-core/otel"
+	"github.com/stretchr/testify/require"
+)
+
+type mockChannel struct {
+	published  [][]byte
+	consumeCh  chan amqp.Delivery
+	closed     bool
+	declareErr error
+	consumeErr error
+	publishErr error
+}
+
+func (m *mockChannel) QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error) {
+	return amqp.Queue{Name: name}, m.declareErr
+}
+
+func (m *mockChannel) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
+	if m.publishErr != nil {
+		return m.publishErr
+	}
+	m.published = append(m.published, msg.Body)
+	return nil
+}
+
+func (m *mockChannel) ConsumeWithContext(ctx context.Context, queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error) {
+	if m.consumeErr != nil {
+		return nil, m.consumeErr
+	}
+	return m.consumeCh, nil
+}
+
+func (m *mockChannel) Close() error { m.closed = true; return nil }
+
+type mockConn struct {
+	ch     *mockChannel
+	closed bool
+}
+
+type errConn struct{}
+
+func (e *errConn) Channel() (amqpChannel, error) { return nil, fmt.Errorf("chan") }
+func (e *errConn) Close() error                  { return nil }
+
+func (c *mockConn) Channel() (amqpChannel, error) { return c.ch, nil }
+func (c *mockConn) Close() error                  { c.closed = true; return nil }
+
+func TestRabbitMQPublishConsumeMock(t *testing.T) {
+	ch := &mockChannel{consumeCh: make(chan amqp.Delivery, 1)}
+	ch.consumeCh <- amqp.Delivery{Body: []byte("consumed")}
+	close(ch.consumeCh)
+
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &mockConn{ch: ch}, nil }
+	defer func() { dialFunc = origDial }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	rmq, err := New(cfg)
+	require.NoError(t, err)
+
+	out, err := rmq.Consume(context.Background(), "q1")
+	require.NoError(t, err)
+
+	require.NoError(t, rmq.Publish(context.Background(), "q1", []byte("hello")))
+	require.Equal(t, []byte("hello"), ch.published[0])
+
+	msg := <-out
+	require.Equal(t, []byte("consumed"), msg)
+}
+
+func TestRabbitMQCloseMock(t *testing.T) {
+	ch := &mockChannel{consumeCh: make(chan amqp.Delivery)}
+	conn := &mockConn{ch: ch}
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return conn, nil }
+	defer func() { dialFunc = origDial }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	rmq, err := New(cfg)
+	require.NoError(t, err)
+
+	_, err = rmq.Consume(context.Background(), "q")
+	require.NoError(t, err)
+	require.NoError(t, rmq.Publish(context.Background(), "q", []byte("x")))
+
+	require.NoError(t, rmq.Close())
+	require.True(t, ch.closed)
+	require.True(t, conn.closed)
+}
+
+func TestRabbitMQPublishCanceledMock(t *testing.T) {
+	ch := &mockChannel{consumeCh: make(chan amqp.Delivery)}
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &mockConn{ch: ch}, nil }
+	defer func() { dialFunc = origDial }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	rmq, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = rmq.Publish(ctx, "q", []byte("x"))
+	require.Error(t, err)
+}
+
+func TestRabbitMQPublishTracingMock(t *testing.T) {
+	ch := &mockChannel{consumeCh: make(chan amqp.Delivery)}
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &mockConn{ch: ch}, nil }
+	defer func() { dialFunc = origDial }()
+
+	logWriter, _, cleanup := setupLogger(t)
+	defer cleanup()
+	resetLogs(logWriter)
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{
+		"otel_enabled": true,
+	}))
+
+	os.Setenv("OTEL_TEST_MOCK_EXPORTER", "true")
+	defer os.Unsetenv("OTEL_TEST_MOCK_EXPORTER")
+	require.NoError(t, otel.Init(cfg))
+	defer otel.Shutdown(context.Background())
+
+	rmq, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, rmq.Publish(ctx, "q", []byte("hi")))
+
+	logs := getLogs(logWriter)
+	require.Contains(t, logs, "\"trace_id\"")
+	require.Contains(t, logs, "\"span_id\"")
+}
+
+func TestRabbitMQConsumeErrorMock(t *testing.T) {
+	ch := &mockChannel{declareErr: fmt.Errorf("boom")}
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &mockConn{ch: ch}, nil }
+	defer func() { dialFunc = origDial }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	rmq, err := New(cfg)
+	require.NoError(t, err)
+
+	_, err = rmq.Consume(context.Background(), "q")
+	require.Error(t, err)
+}
+
+func TestRabbitMQPublishErrorMock(t *testing.T) {
+	ch := &mockChannel{publishErr: fmt.Errorf("boom")}
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &mockConn{ch: ch}, nil }
+	defer func() { dialFunc = origDial }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	rmq, err := New(cfg)
+	require.NoError(t, err)
+
+	err = rmq.Publish(context.Background(), "q", []byte("x"))
+	require.Error(t, err)
+}
+
+func TestRabbitMQNewDialError(t *testing.T) {
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return nil, fmt.Errorf("dial") }
+	defer func() { dialFunc = origDial }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	_, err := New(cfg)
+	require.Error(t, err)
+}
+
+func TestRabbitMQNewChannelError(t *testing.T) {
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &errConn{}, nil }
+	defer func() { dialFunc = origDial }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	_, err := New(cfg)
+	require.Error(t, err)
+}
+
+func TestRabbitMQPublishDeclareErrorMock(t *testing.T) {
+	ch := &mockChannel{declareErr: fmt.Errorf("decl")}
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &mockConn{ch: ch}, nil }
+	defer func() { dialFunc = origDial }()
+
+	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
+	rmq, err := New(cfg)
+	require.NoError(t, err)
+
+	err = rmq.Publish(context.Background(), "q", []byte("x"))
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- add `writerFactoryFunc` and `readerFactoryFunc` so kafka can be tested without a broker
- add `dialFunc` and interfaces so rabbitmq can be tested without a broker
- mock kafka and rabbitmq in new unit tests
- add OpenTelemetry examples for kafka and rabbitmq

## Testing
- `go test ./... -coverprofile=coverage.out`