### PR TITLE
Add OTEL service map examples

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -49,7 +49,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5uk
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
@@ -72,7 +71,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -118,6 +118,10 @@ defer otel.Shutdown(context.Background())
 k, _ := kafka.New(cfg)
 ctx := context.Background()
 _ = k.Publish(ctx, "tasks", []byte("traced"))
+
+msgs, _ := k.Consume(context.Background(), "tasks")
+msg := <-msgs
+fmt.Println(string(msg))
 ```
 
 With tracing enabled, log entries include `trace_id` and `span_id` so you can correlate events across services.

--- a/kafka/examples/otel/main.go
+++ b/kafka/examples/otel/main.go
@@ -28,7 +28,10 @@ func main() {
 	defer k.Close()
 
 	ctx, span := otel.StartSpan(context.Background(), "kafka-example", "publish")
-	defer span.End()
-
 	_ = k.Publish(ctx, "tasks", []byte("hello"))
+	span.End()
+
+	msgs, _ := k.Consume(context.Background(), "tasks")
+	msg := <-msgs
+	logger.InfoContext(ctx, "consumed", logger.String("msg", string(msg)))
 }

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -121,6 +121,10 @@ defer otel.Shutdown(context.Background())
 rmq, _ := rabbitmq.New(cfg)
 ctx := context.Background()
 _ = rmq.Publish(ctx, "tasks", []byte("traced message"))
+
+msgs, _ := rmq.Consume(context.Background(), "tasks")
+msg := <-msgs
+fmt.Println(string(msg))
 ```
 
 Logs produced by `Publish` and `Consume` will include `trace_id` and `span_id` fields when tracing is enabled.

--- a/rabbitmq/examples/otel/main.go
+++ b/rabbitmq/examples/otel/main.go
@@ -28,7 +28,10 @@ func main() {
 	defer rmq.Close()
 
 	ctx, span := otel.StartSpan(context.Background(), "rabbitmq-example", "publish")
-	defer span.End()
-
 	_ = rmq.Publish(ctx, "tasks", []byte("hello"))
+	span.End()
+
+	msgs, _ := rmq.Consume(context.Background(), "tasks")
+	msg := <-msgs
+	logger.InfoContext(ctx, "consumed", logger.String("msg", string(msg)))
 }


### PR DESCRIPTION
## Summary
- update Kafka OTEL example to consume messages
- update RabbitMQ OTEL example to consume messages
- document consuming traces in Kafka and RabbitMQ READMEs

## Testing
- `go test ./...`
