### PR TITLE
Add config flag to toggle OpenTelemetry

### DIFF
--- a/httpc/README.md
+++ b/httpc/README.md
@@ -146,12 +146,10 @@ func main() {
         panic("Failed to initialize config: " + err.Error())
     }
 
-    if cfg.GetBool("otel_enabled") {
-        if err := otel.Init(cfg); err != nil {
-            panic("Failed to initialize otel: " + err.Error())
-        }
-        defer otel.Shutdown(context.Background())
+    if err := otel.Init(cfg); err != nil {
+        panic("Failed to initialize otel: " + err.Error())
     }
+    defer otel.Shutdown(context.Background())
 
     server, err := httpc.NewServer(cfg)
     if err != nil {
@@ -457,14 +455,12 @@ The `httpc` package supports OpenTelemetry tracing for both server and client wh
    ```
 
 3. **Initialize OpenTelemetry**:
-   Before creating the server or client, initialize otel if tracing is enabled:
+   Before creating the server or client, initialize otel:
    ```go
-   if cfg.GetBool("otel_enabled") {
-       if err := otel.Init(cfg); err != nil {
-           panic("Failed to initialize otel: " + err.Error())
-       }
-       defer otel.Shutdown(context.Background())
+   if err := otel.Init(cfg); err != nil {
+       panic("Failed to initialize otel: " + err.Error())
    }
+   defer otel.Shutdown(context.Background())
    ```
 
 4. **Verify Traces**:

--- a/httpc/examples/client/main.go
+++ b/httpc/examples/client/main.go
@@ -37,13 +37,11 @@ func main() {
 		panic("Failed to initialize config: " + err.Error())
 	}
 
-	// Initialize otel if enabled
-	if cfg.GetBool("otel_enabled") {
-		if err := otel.Init(cfg); err != nil {
-			panic("Failed to initialize otel: " + err.Error())
-		}
-		defer otel.Shutdown(context.Background())
+	// Initialize otel
+	if err := otel.Init(cfg); err != nil {
+		panic("Failed to initialize otel: " + err.Error())
 	}
+	defer otel.Shutdown(context.Background())
 
 	// Create client
 	client, err := httpc.NewHTTPClient(cfg)

--- a/httpc/examples/server/main.go
+++ b/httpc/examples/server/main.go
@@ -67,13 +67,11 @@ func main() {
 		panic("Failed to initialize config: " + err.Error())
 	}
 
-	// Initialize otel if enabled
-	if cfg.GetBool("otel_enabled") {
-		if err := otel.Init(cfg); err != nil {
-			panic("Failed to initialize otel: " + err.Error())
-		}
-		defer otel.Shutdown(context.Background())
+	// Initialize otel
+	if err := otel.Init(cfg); err != nil {
+		panic("Failed to initialize otel: " + err.Error())
 	}
+	defer otel.Shutdown(context.Background())
 
 	// Create server
 	server, err := httpc.NewServer(cfg)

--- a/otel/README.md
+++ b/otel/README.md
@@ -242,6 +242,7 @@ The `otel` package is configured via the `OTelConfig` struct, loaded by the `con
 type OTelConfig struct {
     Endpoint string `mapstructure:"otel_endpoint" default:"localhost:4317"`
     Insecure bool   `mapstructure:"otel_insecure" default:"true"`
+    Enabled  bool   `mapstructure:"otel_enabled" default:"false"`
 }
 ```
 
@@ -254,17 +255,23 @@ type OTelConfig struct {
   - Environment variable: `CONFIG_OTEL_INSECURE`
   - Config file key: `otel_insecure`
   - Default: `true`
+- **Enabled**: Toggle OpenTelemetry initialization.
+  - Environment variable: `CONFIG_OTEL_ENABLED`
+  - Config file key: `otel_enabled`
+  - Default: `false`
 
 **Example Config File (config.yaml)**:
 ```yaml
 otel_endpoint: "otel-collector:4317"
 otel_insecure: false
+otel_enabled: true
 ```
 
 **Example Environment Variable**:
 ```bash
 export CONFIG_OTEL_ENDPOINT=otel-collector:4317
 export CONFIG_OTEL_INSECURE=false
+export CONFIG_OTEL_ENABLED=true
 ```
 
 ## Testing

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -23,6 +23,7 @@ import (
 type OTelConfig struct {
 	Endpoint string `mapstructure:"otel_endpoint" default:"localhost:4317"`
 	Insecure bool   `mapstructure:"otel_insecure" default:"true"`
+	Enabled  bool   `mapstructure:"otel_enabled" default:"false"`
 }
 
 var (
@@ -75,6 +76,7 @@ func Init(c *config.Config) error {
 	cfg := OTelConfig{
 		Endpoint: c.GetStringWithDefault("otel_endpoint", "localhost:4317"),
 		Insecure: c.GetBool("otel_insecure"),
+		Enabled:  c.GetBool("otel_enabled"),
 	}
 	return InitWithConfig(c, cfg)
 }
@@ -85,6 +87,12 @@ func InitWithConfig(c *config.Config, cfg OTelConfig) error {
 
 	ctx := context.Background()
 	logger.Info("Initializing OpenTelemetry", logger.Any("config", cfg))
+
+	if !cfg.Enabled {
+		logger.Info("OpenTelemetry disabled via config")
+		tracerProvider = nil
+		return nil
+	}
 
 	// Validate endpoint
 	if err := validateEndpoint(cfg.Endpoint); err != nil {

--- a/otel/otel_test.go
+++ b/otel/otel_test.go
@@ -79,6 +79,8 @@ func resetLogs(writer *syncWriter) {
 }
 
 func TestOTel(t *testing.T) {
+	os.Setenv("CONFIG_OTEL_ENABLED", "true")
+	defer os.Unsetenv("CONFIG_OTEL_ENABLED")
 	cfg, err := config.New(config.WithEnv("CONFIG"))
 	assert.NoError(t, err)
 	t.Logf("Config loaded: %+v", cfg)
@@ -305,6 +307,7 @@ func TestOTel(t *testing.T) {
 		otelCfg := OTelConfig{
 			Endpoint: "otel-collector:4317",
 			Insecure: false,
+			Enabled:  true,
 		}
 		err := InitWithConfig(cfg, otelCfg)
 		assert.NoError(t, err)
@@ -403,6 +406,7 @@ func TestOTel(t *testing.T) {
 			otelCfg := OTelConfig{
 				Endpoint: "invalid.invalid:4317",
 				Insecure: true,
+				Enabled:  true,
 			}
 			errChan := make(chan error, 1)
 			go func() {
@@ -451,6 +455,7 @@ func TestOTel(t *testing.T) {
 			otelCfg := OTelConfig{
 				Endpoint: "localhost:0",
 				Insecure: true,
+				Enabled:  true,
 			}
 			errChan := make(chan error, 1)
 			go func() {
@@ -499,6 +504,7 @@ func TestOTel(t *testing.T) {
 			otelCfg := OTelConfig{
 				Endpoint: "invalid:endpoint",
 				Insecure: true,
+				Enabled:  true,
 			}
 			errChan := make(chan error, 1)
 			go func() {
@@ -550,6 +556,7 @@ func TestOTel(t *testing.T) {
 			otelCfg := OTelConfig{
 				Endpoint: "localhost:4317",
 				Insecure: false,
+				Enabled:  true,
 			}
 			errChan := make(chan error, 1)
 			go func() {
@@ -598,6 +605,7 @@ func TestOTel(t *testing.T) {
 			otelCfg := OTelConfig{
 				Endpoint: "localhost:4317",
 				Insecure: true,
+				Enabled:  true,
 			}
 			err := InitWithConfig(cfg, otelCfg)
 			assert.NoError(t, err, "should succeed with insecure endpoint")
@@ -652,6 +660,7 @@ func TestOTel(t *testing.T) {
 			otelCfg := OTelConfig{
 				Endpoint: "",
 				Insecure: true,
+				Enabled:  true,
 			}
 			err := InitWithConfig(cfg, otelCfg)
 			assert.NoError(t, err, "should succeed with stdout exporter")
@@ -709,6 +718,7 @@ func TestOTel(t *testing.T) {
 			otelCfg := OTelConfig{
 				Endpoint: "",
 				Insecure: true,
+				Enabled:  true,
 			}
 			err := InitWithConfig(cfg, otelCfg)
 			assert.Error(t, err, "should fail with simulated stdout exporter error")
@@ -1049,6 +1059,7 @@ func TestOTel(t *testing.T) {
 				config.WithDefault(map[string]interface{}{
 					"otel_endpoint": "invalid.invalid:4317",
 					"otel_insecure": true,
+					"otel_enabled":  true,
 				}),
 			)
 			assert.NoError(t, err)


### PR DESCRIPTION
## Summary
- support `otel_enabled` flag when initializing OpenTelemetry
- document the new flag and update examples
- simplify HTTP examples to init otel unconditionally
- adapt tests for the new flag

## Testing
- `go test ./...`