### PR TITLE
Add extra tests for higher coverage

### DIFF
--- a/config/env_error_test.go
+++ b/config/env_error_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestWithEnvInvalidFormat ensures WithEnv fails when env vars are not parsable.
+func TestWithEnvInvalidFormat(t *testing.T) {
+	os.Setenv("CONFIG_DEBUG", "notbool")
+	os.Setenv("CONFIG_ENVIRONMENT", "testing")
+	defer os.Unsetenv("CONFIG_DEBUG")
+	defer os.Unsetenv("CONFIG_ENVIRONMENT")
+
+	cfg, err := New(WithEnv("CONFIG"))
+	if err == nil || cfg != nil {
+		t.Fatalf("expected error from invalid env vars, got cfg=%v err=%v", cfg, err)
+	}
+}

--- a/config/invalid_yaml_test.go
+++ b/config/invalid_yaml_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestInvalidYAML ensures invalid YAML files produce an error.
+func TestInvalidYAML(t *testing.T) {
+	tmp, err := os.CreateTemp("", "bad*.yaml")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write([]byte("invalid: [")); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	tmp.Close()
+
+	cfg, err := New(WithFilepath(tmp.Name()))
+	if err == nil || cfg != nil {
+		t.Fatalf("expected error for invalid yaml, got cfg=%v err=%v", cfg, err)
+	}
+}

--- a/httpc/server_additional_test.go
+++ b/httpc/server_additional_test.go
@@ -1,0 +1,62 @@
+package httpc
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+)
+
+// headService provides a HEAD method for testing.
+type headService struct{}
+
+func (s headService) HeadMethod() (string, error) { return "", nil }
+func (s headService) RegisterMethods() []MethodInfo {
+	return []MethodInfo{{Name: "HeadMethod", HTTPMethod: http.MethodHead, InputType: reflect.TypeOf(""), OutputType: reflect.TypeOf(""), Func: reflect.ValueOf(s).MethodByName("HeadMethod")}}
+}
+
+// TestHandleMethodInvalidJSON checks JSON binding failure path.
+func TestHandleMethodInvalidJSON(t *testing.T) {
+	cfgMap, _ := toConfigMap(ServerConfig{OtelEnabled: false, Port: 8080})
+	c, _ := config.New(config.WithDefault(cfgMap))
+	srv, _ := NewServer(c)
+	svc := &TestService{}
+	if err := srv.RegisterService(svc, WithPathPrefix("/v1")); err != nil {
+		t.Fatalf("register service failed: %v", err)
+	}
+	ts := httptest.NewServer(srv.engine)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/Create", bytes.NewBufferString("{"))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestHandleMethodHead verifies HEAD responses.
+func TestHandleMethodHead(t *testing.T) {
+	cfgMap, _ := toConfigMap(ServerConfig{OtelEnabled: false, Port: 8080})
+	c, _ := config.New(config.WithDefault(cfgMap))
+	srv, _ := NewServer(c)
+	hs := &headService{}
+	if err := srv.RegisterService(hs, WithPathPrefix("/v1")); err != nil {
+		t.Fatalf("register service failed: %v", err)
+	}
+	ts := httptest.NewServer(srv.engine)
+	defer ts.Close()
+	resp, err := http.Head(ts.URL + "/v1/HeadMethod")
+	if err != nil {
+		t.Fatalf("head request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}

--- a/httpc/swagger_additional_test.go
+++ b/httpc/swagger_additional_test.go
@@ -1,0 +1,40 @@
+package httpc
+
+import "testing"
+
+// TestUpdateSwaggerDocNilServer verifies error when server is nil.
+func TestUpdateSwaggerDocNilServer(t *testing.T) {
+	err := updateSwaggerDoc(nil, &TestService{}, "/v1")
+	if err == nil {
+		t.Fatal("expected error for nil server")
+	}
+}
+
+// TestUpdateSwaggerDocInvalidMethod ensures methods with invalid HTTP verbs are skipped.
+func TestUpdateSwaggerDocInvalidMethod(t *testing.T) {
+	srv := &Server{swagger: map[string]interface{}{}}
+	svc := &InvalidMethodService{}
+	if err := updateSwaggerDoc(srv, svc, "/v1"); err != nil {
+		t.Fatalf("updateSwaggerDoc returned error: %v", err)
+	}
+	paths := srv.swagger["paths"].(map[string]interface{})
+	if len(paths) != 0 {
+		t.Fatalf("expected no paths registered, got %v", paths)
+	}
+}
+
+// TestUpdateSwaggerDocPrefixFormatting checks that paths have leading slash and swagger defaults initialized.
+func TestUpdateSwaggerDocPrefixFormatting(t *testing.T) {
+	srv := &Server{}
+	svc := &TestService{}
+	if err := updateSwaggerDoc(srv, svc, "v1"); err != nil {
+		t.Fatalf("updateSwaggerDoc returned error: %v", err)
+	}
+	if srv.swagger["openapi"] == nil {
+		t.Fatalf("swagger openapi not set")
+	}
+	paths := srv.swagger["paths"].(map[string]interface{})
+	if _, ok := paths["/v1/Hello"]; !ok {
+		t.Fatalf("expected path with leading slash; got %v", paths)
+	}
+}

--- a/kafka/additional_test.go
+++ b/kafka/additional_test.go
@@ -1,0 +1,53 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	kafka_go "github.com/segmentio/kafka-go"
+)
+
+type errReader struct{}
+
+func (e *errReader) ReadMessage(context.Context) (kafka_go.Message, error) {
+	return kafka_go.Message{}, errors.New("boom")
+}
+func (e *errReader) Close() error { return nil }
+
+type badType struct{ Ch chan int }
+type noWriter struct{}
+
+func (n *noWriter) WriteMessages(context.Context, ...kafka_go.Message) error { return nil }
+func (n *noWriter) Close() error                                             { return nil }
+
+// TestPublishJSONMarshalError ensures PublishJSON returns marshal errors.
+func TestPublishJSONMarshalError(t *testing.T) {
+	origWriter := writerFactoryFunc
+	writerFactoryFunc = func([]string, string) writer { return &noWriter{} }
+	defer func() { writerFactoryFunc = origWriter }()
+	cfg, _ := config.New()
+	k, _ := New(cfg)
+	err := PublishJSON(context.Background(), k, "t", badType{})
+	if err == nil {
+		t.Fatal("expected marshal error")
+	}
+}
+
+// TestConsumeReaderError verifies Consume stops on reader error.
+func TestConsumeReaderError(t *testing.T) {
+	origReader := readerFactoryFunc
+	readerFactoryFunc = func([]string, string) reader { return &errReader{} }
+	defer func() { readerFactoryFunc = origReader }()
+
+	cfg, _ := config.New()
+	k, _ := New(cfg)
+	ch, err := k.Consume(context.Background(), "t")
+	if err != nil {
+		t.Fatalf("consume returned error: %v", err)
+	}
+	if _, ok := <-ch; ok {
+		t.Fatal("expected channel to close on error")
+	}
+}

--- a/otel/additional_test.go
+++ b/otel/additional_test.go
@@ -1,0 +1,36 @@
+package otel
+
+import (
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	"testing"
+)
+
+// TestInitDisabled ensures Init respects disabled config.
+func TestInitDisabled(t *testing.T) {
+	cfg, err := config.New(config.WithDefault(map[string]interface{}{"otel_enabled": false}))
+	if err != nil {
+		t.Fatalf("new config: %v", err)
+	}
+	if err := Init(cfg); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if tracerProvider != nil {
+		t.Fatal("expected tracerProvider nil when disabled")
+	}
+}
+
+// TestValidateEndpoint covers valid and invalid endpoints.
+func TestValidateEndpoint(t *testing.T) {
+	if err := validateEndpoint(""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := validateEndpoint("localhost:4317"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := validateEndpoint("invalid.invalid:4317"); err == nil {
+		t.Fatal("expected invalid hostname error")
+	}
+	if err := validateEndpoint("localhost:99999"); err == nil {
+		t.Fatal("expected invalid port error")
+	}
+}

--- a/rabbitmq/additional_test.go
+++ b/rabbitmq/additional_test.go
@@ -1,0 +1,57 @@
+package rabbitmq
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type errChannel struct{}
+
+func (e *errChannel) QueueDeclare(string, bool, bool, bool, bool, amqp.Table) (amqp.Queue, error) {
+	return amqp.Queue{}, errors.New("decl")
+}
+func (e *errChannel) PublishWithContext(context.Context, string, string, bool, bool, amqp.Publishing) error {
+	return nil
+}
+func (e *errChannel) ConsumeWithContext(context.Context, string, string, bool, bool, bool, bool, amqp.Table) (<-chan amqp.Delivery, error) {
+	return nil, errors.New("consume")
+}
+func (e *errChannel) Close() error { return nil }
+
+type errConnConsume struct{}
+
+func (e *errConnConsume) Channel() (amqpChannel, error) { return &errChannel{}, nil }
+func (e *errConnConsume) Close() error                  { return nil }
+
+type badStruct struct{ Fn func() }
+
+// TestPublishJSONMarshalError verifies PublishJSON returns marshal errors.
+func TestPublishJSONMarshalError(t *testing.T) {
+	cfg, _ := config.New()
+	ch := &mockChannel{consumeCh: make(chan amqp.Delivery)}
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &mockConn{ch: ch}, nil }
+	defer func() { dialFunc = origDial }()
+	rmq, _ := New(cfg)
+	err := PublishJSON(context.Background(), rmq, "q", badStruct{})
+	if err == nil {
+		t.Fatal("expected marshal error")
+	}
+}
+
+// TestConsumeWithChannelError ensures Consume handles ConsumeWithContext errors.
+func TestConsumeWithChannelError(t *testing.T) {
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &errConnConsume{}, nil }
+	defer func() { dialFunc = origDial }()
+	cfg, _ := config.New()
+	rmq, _ := New(cfg)
+	ch, err := rmq.Consume(context.Background(), "q")
+	if err == nil {
+		t.Fatalf("expected error, got channel %v", ch)
+	}
+}


### PR DESCRIPTION
## Summary
- add test covering invalid env setup in config
- add negative YAML file case
- extend swagger tests
- cover additional server behaviors
- add more kafka unit tests
- add otel disabled/validation tests
- add rabbitmq edge case tests

## Testing
- `go test ./... -cover`