### PR TITLE
Add security configs and auto-ack option

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -139,11 +139,14 @@ fmt.Println(msg.Name)
 With tracing enabled, log entries include `trace_id` and `span_id` so you can correlate events across services.
 
 ## Configuration
-| Key             | Type   | Default          |
-| --------------- | ------ | ---------------- |
-| `kafka_brokers` | string | `localhost:9092` |
-| `kafka_topic`   | string | `default`        |
-| `otel_enabled`  | bool   | `false`          |
+| Key              | Type   | Default          |
+| ---------------- | ------ | ---------------- |
+| `kafka_brokers`  | string | `localhost:9092` |
+| `kafka_topic`    | string | `default`        |
+| `otel_enabled`   | bool   | `false`          |
+| `kafka_enable_tls` | bool | `false`          |
+| `kafka_username`   | string | ``              |
+| `kafka_password`   | string | ``              |
 
 Configuration can be loaded from files or environment variables. Example environment usage:
 

--- a/kafka/additional_test.go
+++ b/kafka/additional_test.go
@@ -25,7 +25,7 @@ func (n *noWriter) Close() error                                             { r
 // TestPublishJSONMarshalError ensures PublishJSON returns marshal errors.
 func TestPublishJSONMarshalError(t *testing.T) {
 	origWriter := writerFactoryFunc
-	writerFactoryFunc = func([]string, string) writer { return &noWriter{} }
+	writerFactoryFunc = func([]string, string, Config) writer { return &noWriter{} }
 	defer func() { writerFactoryFunc = origWriter }()
 	cfg, _ := config.New()
 	k, _ := New(cfg)
@@ -38,7 +38,7 @@ func TestPublishJSONMarshalError(t *testing.T) {
 // TestConsumeReaderError verifies Consume stops on reader error.
 func TestConsumeReaderError(t *testing.T) {
 	origReader := readerFactoryFunc
-	readerFactoryFunc = func([]string, string) reader { return &errReader{} }
+	readerFactoryFunc = func([]string, string, Config) reader { return &errReader{} }
 	defer func() { readerFactoryFunc = origReader }()
 
 	cfg, _ := config.New()

--- a/kafka/mock_test.go
+++ b/kafka/mock_test.go
@@ -42,8 +42,8 @@ func TestKafkaPublishConsumeMock(t *testing.T) {
 	close(mr.ch)
 
 	origW, origR := writerFactoryFunc, readerFactoryFunc
-	writerFactoryFunc = func([]string, string) writer { return mw }
-	readerFactoryFunc = func([]string, string) reader { return mr }
+	writerFactoryFunc = func([]string, string, Config) writer { return mw }
+	readerFactoryFunc = func([]string, string, Config) reader { return mr }
 	defer func() { writerFactoryFunc, readerFactoryFunc = origW, origR }()
 
 	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
@@ -73,8 +73,8 @@ func TestKafkaPublishConsumeJSONMock(t *testing.T) {
 	close(mr.ch)
 
 	origW, origR := writerFactoryFunc, readerFactoryFunc
-	writerFactoryFunc = func([]string, string) writer { return mw }
-	readerFactoryFunc = func([]string, string) reader { return mr }
+	writerFactoryFunc = func([]string, string, Config) writer { return mw }
+	readerFactoryFunc = func([]string, string, Config) reader { return mr }
 	defer func() { writerFactoryFunc, readerFactoryFunc = origW, origR }()
 
 	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
@@ -99,8 +99,8 @@ func TestKafkaCloseMock(t *testing.T) {
 	mr := &mockReader{ch: make(chan kafka_go.Message)}
 
 	origW, origR := writerFactoryFunc, readerFactoryFunc
-	writerFactoryFunc = func([]string, string) writer { return mw }
-	readerFactoryFunc = func([]string, string) reader { return mr }
+	writerFactoryFunc = func([]string, string, Config) writer { return mw }
+	readerFactoryFunc = func([]string, string, Config) reader { return mr }
 	defer func() { writerFactoryFunc, readerFactoryFunc = origW, origR }()
 
 	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
@@ -118,7 +118,7 @@ func TestKafkaPublishCanceledMock(t *testing.T) {
 	mw := &mockWriter{}
 
 	origW := writerFactoryFunc
-	writerFactoryFunc = func([]string, string) writer { return mw }
+	writerFactoryFunc = func([]string, string, Config) writer { return mw }
 	defer func() { writerFactoryFunc = origW }()
 
 	cfg, _ := config.New(config.WithDefault(map[string]interface{}{}))
@@ -135,8 +135,8 @@ func TestKafkaPublishInjectsTraceContext(t *testing.T) {
 	mw := &mockWriter{}
 	mr := &mockReader{ch: make(chan kafka_go.Message)}
 	origW, origR := writerFactoryFunc, readerFactoryFunc
-	writerFactoryFunc = func([]string, string) writer { return mw }
-	readerFactoryFunc = func([]string, string) reader { return mr }
+	writerFactoryFunc = func([]string, string, Config) writer { return mw }
+	readerFactoryFunc = func([]string, string, Config) reader { return mr }
 	defer func() { writerFactoryFunc, readerFactoryFunc = origW, origR }()
 
 	cfg, _ := config.New(config.WithDefault(map[string]interface{}{


### PR DESCRIPTION
## Summary
- add TLS and SASL fields to Kafka config
- support security settings in kafka reader/writer factories
- add TLS and AutoAck options to RabbitMQ
- document new Kafka configuration options
- update tests for new factory signatures

## Testing
- `go test ./...`