### PR TITLE
Add basic tests

### DIFF
--- a/httpc/parse_test.go
+++ b/httpc/parse_test.go
@@ -1,0 +1,54 @@
+package httpc
+
+import "testing"
+
+func TestParseInt(t *testing.T) {
+	n, err := parseInt("42")
+	if err != nil {
+		t.Fatalf("parseInt returned error: %v", err)
+	}
+	if n != 42 {
+		t.Fatalf("expected 42, got %d", n)
+	}
+	if _, err := parseInt("a"); err == nil {
+		t.Fatal("expected error for invalid input")
+	}
+}
+
+func TestParseFloat(t *testing.T) {
+	f, err := parseFloat("3.14")
+	if err != nil {
+		t.Fatalf("parseFloat returned error: %v", err)
+	}
+	if f != 3.14 {
+		t.Fatalf("expected 3.14, got %f", f)
+	}
+	if _, err := parseFloat("a"); err == nil {
+		t.Fatal("expected error for invalid input")
+	}
+}
+
+func TestWithPathPrefix(t *testing.T) {
+	cfg := serviceConfig{}
+	opt := WithPathPrefix("/api")
+	opt(&cfg)
+	if cfg.prefix != "/api" {
+		t.Fatalf("expected /api, got %s", cfg.prefix)
+	}
+}
+
+func TestMultiMethodServiceMethods(t *testing.T) {
+	s := MultiMethodService{}
+	if out, err := s.GetMethod("name"); err != nil || out.Result != "GET: name" {
+		t.Fatalf("unexpected result: %v %v", out, err)
+	}
+	if out, err := s.PostMethod(MultiInput{Value: "x"}); err != nil || out.Result != "POST: x" {
+		t.Fatalf("unexpected result: %v %v", out, err)
+	}
+	if out, err := s.PutMethod(MultiInput{Value: "x"}); err != nil || out.Result != "PUT: x" {
+		t.Fatalf("unexpected result: %v %v", out, err)
+	}
+	if out, err := s.DeleteMethod(MultiInput{Value: "x"}); err != nil || out.Result != "DELETE: x" {
+		t.Fatalf("unexpected result: %v %v", out, err)
+	}
+}

--- a/rabbitmq/channel_close_test.go
+++ b/rabbitmq/channel_close_test.go
@@ -1,0 +1,49 @@
+package rabbitmq
+
+import (
+	"context"
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+
+	"github.com/T-Prohmpossadhorn/go-core/config"
+)
+
+// mockChan to test Channel method
+type mockChan struct{}
+
+func (m *mockChan) QueueDeclare(string, bool, bool, bool, bool, amqp.Table) (amqp.Queue, error) {
+	return amqp.Queue{}, nil
+}
+func (m *mockChan) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
+	return nil
+}
+func (m *mockChan) ConsumeWithContext(ctx context.Context, queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error) {
+	return nil, nil
+}
+func (m *mockChan) Close() error { return nil }
+
+type mockConnForChannel struct{}
+
+func (m *mockConnForChannel) Channel() (amqpChannel, error) { return &mockChan{}, nil }
+func (m *mockConnForChannel) Close() error                  { return nil }
+
+func TestRabbitMQChannelClose(t *testing.T) {
+	origDial := dialFunc
+	dialFunc = func(string) (amqpConn, error) { return &mockConnForChannel{}, nil }
+	defer func() { dialFunc = origDial }()
+
+	cfg, _ := config.New()
+	r, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if r.channel == nil {
+		t.Fatal("expected channel initialized")
+	}
+
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add coverage tests for httpc helpers and services
- add coverage test for RabbitMQ channel closing

## Testing
- `go test ./... -cover`